### PR TITLE
Update ShoppingListDeleteController.php

### DIFF
--- a/src/SprykerShop/Yves/ShoppingListPage/Controller/ShoppingListDeleteController.php
+++ b/src/SprykerShop/Yves/ShoppingListPage/Controller/ShoppingListDeleteController.php
@@ -67,11 +67,15 @@ class ShoppingListDeleteController extends AbstractShoppingListController
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
      *
-     * @return \Spryker\Yves\Kernel\View\View
+     * @return \Spryker\Yves\Kernel\View\View|\Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function deleteConfirmAction(Request $request): View
+    public function deleteConfirmAction(Request $request)
     {
         $response = $this->executeDeleteConfirmAction($request);
+
+        if ($response['shoppingList']->getIdShoppingList() === null) {
+            return $this->redirectResponseInternal('shopping-list');
+        }
 
         return $this->view($response, [], '@ShoppingListPage/views/shopping-list-overview-delete/shopping-list-overview-delete.twig');
     }


### PR DESCRIPTION
If the shopping list is already deleted an exception is thrown in twig because the idShoppingList is null and the route to delete the shopping list can not get generated. 
To avoid this fail whale we want to redirect the customer back to the shopping list page. Unfortunately it is not possible without creating a new route, controller, .... because the Return Type of the deleteConfirmAction is fixed to View and does not allow a RedirectResponse. 

For that reason we suggest to remove the return type of this method.

This happens if a customer hits the back button in the browser directly after deleting a shopping list.